### PR TITLE
Adding API Function to Relay Text

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -115,6 +115,26 @@ libwebsock_send_all_text(libwebsock_context *ctx, char *strdata)
 }
 
 int
+libwebsock_send_others_text(libwebsock_client_state *state, char *strdata)
+{
+  unsigned int count = 0;
+  unsigned int len = strlen(strdata);
+  int flags = WS_FRAGMENT_FIN | WS_OPCODE_TEXT;
+  libwebsock_context *ctx = state->ctx;
+  libwebsock_client_state *current;
+  if (ctx->clients_HEAD == NULL) {
+    return 0;
+  }
+  for (current = ctx->clients_HEAD; current != NULL; current = current->next) {
+    if(current == state) continue;
+    libwebsock_send_fragment(current, strdata, len, flags);
+    count++;
+  }
+
+  return count;
+}
+
+int
 libwebsock_send_text(libwebsock_client_state *state, char *strdata)
 {
   unsigned int len = strlen(strdata);

--- a/src/api.h
+++ b/src/api.h
@@ -27,6 +27,7 @@ int libwebsock_close(libwebsock_client_state *state);
 int libwebsock_close_with_reason(libwebsock_client_state *state, unsigned short code, const char *reason);
 int libwebsock_send_binary(libwebsock_client_state *state, char *in_data, unsigned int payload_len);
 int libwebsock_send_all_text(libwebsock_context *ctx, char *strdata);
+int libwebsock_send_others_text(libwebsock_client_state *state, char *strdata);
 int libwebsock_send_text(libwebsock_client_state *state, char *strdata);
 int libwebsock_send_text_with_length(libwebsock_client_state *state, char *strdata, unsigned int payload_len);
 void libwebsock_wait(libwebsock_context *ctx);

--- a/src/websock_config.h
+++ b/src/websock_config.h
@@ -2,7 +2,7 @@
 #ifndef WEBSOCK_CONFIG_H
 #define WEBSOCK_CONFIG_H 1
 
-#define LIBWEBSOCK_DEBUG 0
+// #define LIBWEBSOCK_DEBUG 1
 
 #define WEBSOCK_PACKAGE_STRING "libwebsock 1.0.7"
 #define WEBSOCK_PACKAGE_VERSION "1.0.7"


### PR DESCRIPTION
New API function `libwebsock_send_others_text(libwebsock_client_state *state, char *strdata)` sends the provided text to all other connected clients other than the `state` passed to the function.
