### PR TITLE
configure: check for pthread at the very beginning, to avoid dependen…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,14 +27,14 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([memset socket strstr])
 
+AC_CHECK_LIB(pthread, pthread_create, [LIBS="-lpthread"], [
+                                                echo "pthreads required, failing"
+                                                exit -1
+                                                ])
 AC_CHECK_HEADERS([event2/thread.h], [
 					LIBS="-levent_pthreads ${LIBS}"
 				    ], [
                                                 echo "libevent_pthreads required, failing"
-                                                exit -1
-                                                ])
-AC_CHECK_LIB(pthread, pthread_create, [LIBS="-lpthread ${LIBS}"], [
-                                                echo "pthreads required, failing"
                                                 exit -1
                                                 ])
 AC_CHECK_LIB(event, event_base_dispatch, [], [


### PR DESCRIPTION
…cies for it

Otherwise you need to link event/event_core too to get all undefined symbols in
event_pthread, like event_mm_malloc_() and all others.
